### PR TITLE
Update version listing in bower.json to 1.1.1

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,6 @@
 {
   "name": "jquery-repeater",
-  "version": "1.1",
+  "version": "1.1.1",
   "homepage": "https://github.com/incraigulous/jquery-repeater",
   "authors": [
     "Incraigulous"


### PR DESCRIPTION
When I try installing jquery-repeater via `bower install jquery-repeater`, I get the following error: `Invalid Version: 1.1`. I believe this is related to a mismatch between the Git tag and the version listed in bower.json?
