### PR TITLE
Updated callback to include reference to new container

### DIFF
--- a/jquery-repeater.js
+++ b/jquery-repeater.js
@@ -5,7 +5,7 @@ var Repeater = new Class({
         removeSelector: '.repeater-remove',
         withDataAndEvents: false,
         deepWithDataAndEvents: false,
-        addCallback: function(){},
+        addCallback: function( newContainer ){},
         wrapperHtml: "<div class='repeater-wrap'></div>"
     },
     i: 0,
@@ -48,7 +48,7 @@ var Repeater = new Class({
         this.incrementContainerAttributes(newContainer);
         this.initContainerButtons(newContainer);
         $(newContainer).appendTo(this.wrapper);
-        this.options.addCallback();
+        this.options.addCallback( newContainer );
         this.i++;
     },
 


### PR DESCRIPTION
The callback becomes more useful by passing the new container to the callback function as the primary argument